### PR TITLE
Check body valid

### DIFF
--- a/addons/destruction/destruction.gd
+++ b/addons/destruction/destruction.gd
@@ -100,13 +100,16 @@ func _add_shard(original: MeshInstance3D, explosion_power: float) -> void:
 	body.apply_impulse(_random_direction() * explosion_power,
 			-original.position.normalized())
 	if shrink_delay < 0 and fade_delay < 0:
-		get_tree().create_timer(animation_length)\
-				.timeout.connect(func(): if is_instance_valid(body): body.queue_free())
+		var tween := get_tree().create_tween()
+		tween.bind_node(body)
+		tween.create_timer(animation_length)\
+				.timeout.connect(func(): body.queue_free())
 	elif shrink_delay >= 0:
 		var tween := get_tree().create_tween()
+		tween.bind_node(body)
 		tween.tween_property(mesh, "scale", Vector3.ZERO, animation_length)\
 				.set_delay(shrink_delay)
-		tween.finished.connect(func(): if is_instance_valid(body): body.queue_free())
+		tween.finished.connect(func(): body.queue_free())
 
 
 static func _random_direction() -> Vector3:

--- a/addons/destruction/destruction.gd
+++ b/addons/destruction/destruction.gd
@@ -106,7 +106,7 @@ func _add_shard(original: MeshInstance3D, explosion_power: float) -> void:
 		var tween := get_tree().create_tween()
 		tween.tween_property(mesh, "scale", Vector3.ZERO, animation_length)\
 				.set_delay(shrink_delay)
-		tween.finished.connect(func(): if is_instance_valid(body):body.queue_free())
+		tween.finished.connect(func(): if is_instance_valid(body): body.queue_free())
 
 
 static func _random_direction() -> Vector3:

--- a/addons/destruction/destruction.gd
+++ b/addons/destruction/destruction.gd
@@ -101,12 +101,12 @@ func _add_shard(original: MeshInstance3D, explosion_power: float) -> void:
 			-original.position.normalized())
 	if shrink_delay < 0 and fade_delay < 0:
 		get_tree().create_timer(animation_length)\
-				.timeout.connect(func(): body.queue_free())
+				.timeout.connect(func():if is_instance_valid(body): body.queue_free())
 	elif shrink_delay >= 0:
 		var tween := get_tree().create_tween()
 		tween.tween_property(mesh, "scale", Vector3.ZERO, animation_length)\
 				.set_delay(shrink_delay)
-		tween.finished.connect(func(): body.queue_free())
+		tween.finished.connect(func(): if is_instance_valid(body):body.queue_free())
 
 
 static func _random_direction() -> Vector3:

--- a/addons/destruction/destruction.gd
+++ b/addons/destruction/destruction.gd
@@ -101,7 +101,7 @@ func _add_shard(original: MeshInstance3D, explosion_power: float) -> void:
 			-original.position.normalized())
 	if shrink_delay < 0 and fade_delay < 0:
 		get_tree().create_timer(animation_length)\
-				.timeout.connect(func():if is_instance_valid(body): body.queue_free())
+				.timeout.connect(func(): if is_instance_valid(body): body.queue_free())
 	elif shrink_delay >= 0:
 		var tween := get_tree().create_tween()
 		tween.tween_property(mesh, "scale", Vector3.ZERO, animation_length)\


### PR DESCRIPTION
Adds a check for the body being valid before freeing (in my case, I'm potentially deleting parent nodes its attached to). Used `is_instance_valid()` to support versions older than Godot version 4.3. (where you can just do `if object:`)